### PR TITLE
Correct parentheses in B-sets

### DIFF
--- a/Csystemfromamonad.tex
+++ b/Csystemfromamonad.tex
@@ -982,19 +982,19 @@ $$B(\RR,\LM)=\coprod_{n\ge 0} \prod_{i=0}^{n-1}LM(\ff{i})$$
 %
 \item a sentence of the form (\ref{2017.02.06.eq2}) is an element of
 %
-$$Bt(\RR,\LM)=\left(\coprod_{n\ge 0} \prod_{i=0}^{n-1}LM(\ff{i})\right)\times LM(\ff{n})$$
+$$Bt(\RR,\LM)=\coprod_{n\ge 0} \left(\prod_{i=0}^{n-1}LM(\ff{i})\times LM(\ff{n})\right)$$
 %
 \item a sentence of the form (\ref{2017.02.06.eq3}) is an element of
 %
-$$\wt{B}(\RR,\LM)=\left(\coprod_{n\ge 0} \prod_{i=0}^{n-1}LM(\ff{i})\right)\times RR(\ff{n})\times LM(\ff{n})$$
+$$\wt{B}(\RR,\LM)=\coprod_{n\ge 0} \left(\prod_{i=0}^{n-1}LM(\ff{i})\times RR(\ff{n})\times LM(\ff{n})\right)$$
 %
 \item a sentence of the form (\ref{2017.02.06.eq4}) is an element of
 %
-$$Beq(\RR,\LM)=\left(\coprod_{n\ge 0} \prod_{i=0}^{n-1}LM(\ff{i})\right)\times LM(\ff{n})\times LM(\ff{n})$$
+$$Beq(\RR,\LM)=\coprod_{n\ge 0} \left(\prod_{i=0}^{n-1}LM(\ff{i})\times LM(\ff{n})\times LM(\ff{n})\right)$$
 %
 \item a sentence of the form (\ref{2017.02.06.eq5}) is an element of
 %
-$$\wt{Beq}(\RR,\LM)=\left(\coprod_{n\ge 0} \prod_{i=0}^{n-1}LM(\ff{i})\right)\times RR(\ff{n})\times RR(\ff{n})\times LM(\ff{n})$$
+$$\wt{Beq}(\RR,\LM)=\coprod_{n\ge 0} \left(\prod_{i=0}^{n-1}LM(\ff{i})\times RR(\ff{n})\times RR(\ff{n})\times LM(\ff{n})\right)$$
 %
 \end{enumerate}
 %


### PR DESCRIPTION
This new version still relies on the fact that `\prod` binds more tightly than `\times` - not sure if extra parens should be inserted to avoid that ambiguity.