### PR TITLE
change indices to unify with later use

### DIFF
--- a/Csystemfromamonad.tex
+++ b/Csystemfromamonad.tex
@@ -604,7 +604,7 @@ an inclusion of algebraic signatures into binding signatures. The earliest
 mention of a concept equivalent to binding arity that we know of is in
 \cite{Aczel1978}. The meaning of an operation $E$ with algebraic arity $d$
 is that $E$ has $d$ arguments. The meaning of an operation $E$ with binding
-arity $(i_1,\dots,i_d)$ is that $E$ has $d$ arguments and binds $i_k$ variables
+arity $(i_0,\dots,i_{d-1})$ is that $E$ has $d$ arguments and binds $i_k$ variables
 in its $k$-th argument.
 
 To apply an operation $Op$ with arity $(n_0,\dots,n_{d-1})$ to expressions


### PR DESCRIPTION
Suggestion, not correction of a mistake

In the next paragraph, indices go from 0 to d-1, so why not here as well?