### PR TITLE
underline some natural numbers

### DIFF
--- a/Csystemfromamonad.tex
+++ b/Csystemfromamonad.tex
@@ -1011,8 +1011,8 @@ over it.  Namely, if $E_1,\dots,E_k\in RR(\ff{m})$,
 $E\in RR(\ff{n})$ and $0\le i_1,\dots,i_k\le n-1$, then 
 $E[E_1/i_1,\dots,E_k/i_k]\in RR(\ff{m})$ is the element $rr(f)(E)$, where $f:stn(n)\sr RR(\ff{m})$ is given
 by $f(i)=\eta{i}$ for $i\ne i_1,\dots,i_k$ and $f(i_j)=E_j$. Exactly the same
-formula with the replacement of $RR(n)$ by $LM(n)$ describes
-$T[E_1/i_1,\dots,E_k/i_k]$ for $T\in LM(n)$.
+formula with the replacement of $RR(n)$ by $LM(\ff{n})$ describes
+$T[E_1/i_1,\dots,E_k/i_k]$ for $T\in LM(\ff{n})$.
 
 This completes a large section of our introduction. We can now view the
 $\alpha$-equivalence classes of the type expressions and the element expressions with given
@@ -1027,7 +1027,7 @@ context. Using this $\alpha$-equivalence we may assume that
 $(x_0,\dots,x_{n-1})=(0,\dots,n-1)$. Then $T_i$ has free variables from
 $stn(i)$, and $T$, $T'$, $t$, and $t'$ have free variables from $stn(n)$. When we are given
 all the necessary additional information for the construction of the pair
-$(\RR,\LM)$, where $RR(n)$ and $LM(n)$ are the $\alpha$-equivalence classes of
+$(\RR,\LM)$, where $RR(\ff{n})$ and $LM(\ff{n})$ are the $\alpha$-equivalence classes of
 type and element expressions with free variables from the sets $stn(n)$, then we
 obtain the following description of the sets of all possible sentences of the
 five main kinds.


### PR DESCRIPTION
Just before, the natural numbers are underlined when being arguments to RR or LM.