### PR TITLE
add missing boldfont in C(RR)

### DIFF
--- a/Csystemfromamonad.tex
+++ b/Csystemfromamonad.tex
@@ -1487,7 +1487,7 @@ the length function $Ob(CC)\sr \nat$ is a bijection. In Section \ref{CRR} we
 consider the C-system $C(\RR)$ corresponding to the Lawvere theory $RML(\RR)$
 defined by a $Jf$-relative monad $\RR$. The underlying category of this
 C-system is $K(\RR)^{op}$. The main result of this section is the description
-of the B-sets of $C(RR)$ and of the actions of the B-system operations on these
+of the B-sets of $C(\RR)$ and of the actions of the B-system operations on these
 sets.
 
 In the final Section \ref{CRRLM} we apply the construction of Section
@@ -4143,8 +4143,8 @@ In substitution notation this can be seen as follows:
 In this paper we are interested in $Jf$-relative monads $\RR$. The
 corresponding Kleisli categories are the categories opposite to the categories
 $C(\RR)$ underlying the C-systems considered above. Therefore, left modules
-over a $Jf$-monad $\RR$ with values in $Sets$ are the presheaves on $C(RR)$,
-i.e., the contravariant functors from $C(RR)$ to $Sets$.
+over a $Jf$-monad $\RR$ with values in $Sets$ are the presheaves on $C(\RR)$,
+i.e., the contravariant functors from $C(\RR)$ to $Sets$.
 
 Let $\LM=(LM,LM_{Mor})$ be such a presheaf.
 %
@@ -4220,7 +4220,7 @@ and therefore objects of $C(\RR,\LM)$ are pairs of the form $(n,\Gamma)$, where
 $\Gamma$ is a sequence $(T_0,\dots,T_{n-1})$, where $T_i\in LM(\wh{i})$. While
 the number $n$ in a pair $(n,\Gamma)$ is an object of $C(\RR)$ we will not add
 the ${\,\,\wh{}\,\,}$ diacritic to it since no confusion of the kind possible
-with objects of $C(RR)$ and objects of $F$ can arise. We may sometimes omit $n$
+with objects of $C(\RR)$ and objects of $F$ can arise. We may sometimes omit $n$
 from our notation altogether since it can be recovered from
 $\Gamma$. Similarly, while the morphisms of $C(\RR,\LM)$ are given by iterated
 pairs of the form $(((m,\Gamma),(n,\Gamma')),((\wh{m},\wh{n}),f))$, where $f\in


### PR DESCRIPTION
C(RR) -> C(\RR)

I checked for the possibility that something different was meant by C(RR) than by C(\RR), i.e., that there was a purposeful distinction. But this is not the case.